### PR TITLE
fix issue with multiple audio tracks

### DIFF
--- a/mpv2anki.lua
+++ b/mpv2anki.lua
@@ -149,6 +149,7 @@ function create_audio(
         'mpv', mp.get_property('path'),
         '--start=' .. start_time,
         '--end=' .. end_time,
+        '--aid=' .. mp.get_property("aid"),
         '--vid=no',
         '--loop-file=no',
         '--oacopts=b=' .. bitrate,


### PR DESCRIPTION
When playing video with multiple audio tracks, mpv2anki will export the first audio track even when the second audio track is chosen.  This PR should fix this issue.